### PR TITLE
Add custom model training template

### DIFF
--- a/training/custom-model/README.md
+++ b/training/custom-model/README.md
@@ -1,0 +1,26 @@
+# Custom Model Training Template
+
+This directory provides a minimal template for training a custom model on a
+custom dataset with [DeepSpeed](https://www.deepspeed.ai/).  Only the model and
+dataset paths need to be updated before launching training.
+
+## Files
+
+- `train.py` – simple training loop using DeepSpeed.
+- `ds_config.json` – example DeepSpeed configuration.
+- `run.sh` – helper script for launching multi-node training.
+- `hostfile` – placeholder listing the machines in the cluster.
+
+## Usage
+
+1. Edit `run.sh` and update `MODEL_PATH` and `DATASET_PATH` with the desired
+   model and dataset.
+2. Update `hostfile` with the hostname and GPU count for each node.
+3. Launch training:
+   ```bash
+   ./run.sh
+   ```
+4. Trained checkpoints will be written to the `output` directory.
+
+`train.py` assumes the dataset contains a `text` column and will tokenize and
+train a causal language model.  Adjust the script as needed for other tasks.

--- a/training/custom-model/ds_config.json
+++ b/training/custom-model/ds_config.json
@@ -1,0 +1,17 @@
+{
+  "train_batch_size": 8,
+  "train_micro_batch_size_per_gpu": 2,
+  "steps_per_print": 10,
+  "optimizer": {
+    "type": "AdamW",
+    "params": {
+      "lr": 5e-5,
+      "betas": [0.9, 0.999],
+      "eps": 1e-8,
+      "weight_decay": 1e-2
+    }
+  },
+  "fp16": {
+    "enabled": true
+  }
+}

--- a/training/custom-model/hostfile
+++ b/training/custom-model/hostfile
@@ -1,0 +1,6 @@
+# Example hostfile for DeepSpeed multi-node training
+# Format: <hostname> slots=<num_gpus>
+# Update the hostnames and GPU counts for your cluster
+worker-0 slots=8
+worker-1 slots=8
+

--- a/training/custom-model/run.sh
+++ b/training/custom-model/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Launch DeepSpeed training on a multi-node cluster.
+# Edit MODEL_PATH and DATASET_PATH to point to your model and dataset.
+
+set -e
+
+MODEL_PATH="/path/to/model"
+DATASET_PATH="/path/to/dataset"
+OUTPUT_DIR="output"
+
+NUM_NODES=${NUM_NODES:-2}
+NUM_GPUS=${NUM_GPUS:-8}
+HOSTFILE=${HOSTFILE:-hostfile}
+
+mkdir -p ${OUTPUT_DIR}
+
+deepspeed --num_nodes ${NUM_NODES} --num_gpus ${NUM_GPUS} --hostfile ${HOSTFILE} \
+  train.py \
+  --deepspeed ds_config.json \
+  --model_name_or_path ${MODEL_PATH} \
+  --dataset_path ${DATASET_PATH} \
+  --output_dir ${OUTPUT_DIR}
+

--- a/training/custom-model/train.py
+++ b/training/custom-model/train.py
@@ -1,0 +1,68 @@
+"""Minimal example of training a custom model with DeepSpeed.
+
+Only the dataset path and model path need to be provided.  The script loads a
+causal language model, tokenizes the dataset and runs a simple training loop
+using DeepSpeed for distributed execution.
+"""
+
+import argparse
+from typing import Dict
+
+import deepspeed
+from datasets import load_dataset
+from torch.utils.data import DataLoader
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a custom model")
+    parser.add_argument("--model_name_or_path", type=str, required=True,
+                        help="Path or name of the model to fine-tune")
+    parser.add_argument("--dataset_path", type=str, required=True,
+                        help="Path to a text dataset file")
+    parser.add_argument("--output_dir", type=str, default="output",
+                        help="Where to store the trained model")
+    parser.add_argument("--deepspeed", type=str, default=None,
+                        help="DeepSpeed config file")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
+    model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path)
+
+    dataset = load_dataset("text", data_files={"train": args.dataset_path})["train"]
+
+    def tokenize(batch: Dict[str, list]) -> Dict[str, list]:
+        return tokenizer(batch["text"], truncation=True, padding="max_length",
+                         max_length=tokenizer.model_max_length)
+
+    dataset = dataset.map(tokenize, batched=True, remove_columns=["text"])
+    dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
+
+    engine, _, _, _ = deepspeed.initialize(
+        args=args, model=model, model_parameters=model.parameters()
+    )
+
+    train_loader = DataLoader(
+        dataset, batch_size=engine.config.train_micro_batch_size_per_gpu, shuffle=True
+    )
+
+    for step, batch in enumerate(train_loader):
+        batch = {k: v.to(engine.device) for k, v in batch.items()}
+        outputs = engine(**batch, labels=batch["input_ids"])
+        loss = outputs.loss
+        engine.backward(loss)
+        engine.step()
+        if step % 10 == 0 and engine.global_rank == 0:
+            print(f"step {step} loss {loss.item():.4f}")
+
+    if engine.global_rank == 0:
+        engine.module.save_pretrained(args.output_dir)
+        tokenizer.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- add `training/custom-model` example with placeholder scripts to train any model and dataset with DeepSpeed
- include multi-node launch script, hostfile template, and DeepSpeed config